### PR TITLE
Add u16, u256, and u512 for ser/de with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ const newValue = borsh.deserialize(schema, Test, buffer);
 | `u32` integer         | `number`       |
 | `u64` integer         | `BN`           |
 | `u128` integer        | `BN`           |
+| `u256` integer        | `BN`           |
+| `u512` integer        | `BN`           |
 | `f32` float           | N/A            |
 | `f64` float           | N/A            |
 | fixed-size byte array | `Uint8Array`   |

--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -59,6 +59,12 @@ export class BinaryWriter {
         this.length += 1;
     }
 
+    public writeU16(value: number) {
+        this.maybeResize();
+        this.buf.writeUInt16LE(value, this.length);
+        this.length += 2;
+    }
+
     public writeU32(value: number) {
         this.maybeResize();
         this.buf.writeUInt32LE(value, this.length);
@@ -73,6 +79,16 @@ export class BinaryWriter {
     public writeU128(value: BN) {
         this.maybeResize();
         this.writeBuffer(Buffer.from(new BN(value).toArray('le', 16)));
+    }
+
+    public writeU256(value: BN) {
+        this.maybeResize();
+        this.writeBuffer(Buffer.from(new BN(value).toArray('le', 32)));
+    }
+
+    public writeU512(value: BN) {
+        this.maybeResize();
+        this.writeBuffer(Buffer.from(new BN(value).toArray('le', 64)));
     }
 
     private writeBuffer(buffer: Buffer) {
@@ -140,6 +156,13 @@ export class BinaryReader {
     }
 
     @handlingRangeError
+    readU16(): number {
+        const value = this.buf.readUInt16LE(this.offset);
+        this.offset += 2;
+        return value;
+    }
+
+    @handlingRangeError
     readU32(): number {
         const value = this.buf.readUInt32LE(this.offset);
         this.offset += 4;
@@ -155,6 +178,18 @@ export class BinaryReader {
     @handlingRangeError
     readU128(): BN {
         const buf = this.readBuffer(16);
+        return new BN(buf, 'le');
+    }
+
+    @handlingRangeError
+    readU256(): BN {
+        const buf = this.readBuffer(32);
+        return new BN(buf, 'le');
+    }
+
+    @handlingRangeError
+    readU512(): BN {
+        const buf = this.readBuffer(64);
         return new BN(buf, 'le');
     }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,9 +15,12 @@ export declare class BinaryWriter {
     constructor();
     maybeResize(): void;
     writeU8(value: number): void;
+    writeU16(value: number): void;
     writeU32(value: number): void;
     writeU64(value: BN): void;
     writeU128(value: BN): void;
+    writeU256(value: BN): void;
+    writeU512(value: BN): void;
     private writeBuffer;
     writeString(str: string): void;
     writeFixedArray(array: Uint8Array): void;
@@ -29,9 +32,12 @@ export declare class BinaryReader {
     offset: number;
     constructor(buf: Buffer);
     readU8(): number;
+    readU16(): number;
     readU32(): number;
     readU64(): BN;
     readU128(): BN;
+    readU256(): BN;
+    readU512(): BN;
     private readBuffer;
     readString(): string;
     readFixedArray(len: number): Uint8Array;

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,11 @@ class BinaryWriter {
         this.buf.writeUInt8(value, this.length);
         this.length += 1;
     }
+    writeU16(value) {
+        this.maybeResize();
+        this.buf.writeUInt16LE(value, this.length);
+        this.length += 2;
+    }
     writeU32(value) {
         this.maybeResize();
         this.buf.writeUInt32LE(value, this.length);
@@ -88,6 +93,14 @@ class BinaryWriter {
     writeU128(value) {
         this.maybeResize();
         this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 16)));
+    }
+    writeU256(value) {
+        this.maybeResize();
+        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 32)));
+    }
+    writeU512(value) {
+        this.maybeResize();
+        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 64)));
     }
     writeBuffer(buffer) {
         // Buffer.from is needed as this.buf.subarray can return plain Uint8Array in browser
@@ -143,6 +156,11 @@ class BinaryReader {
         this.offset += 1;
         return value;
     }
+    readU16() {
+        const value = this.buf.readUInt16LE(this.offset);
+        this.offset += 2;
+        return value;
+    }
     readU32() {
         const value = this.buf.readUInt32LE(this.offset);
         this.offset += 4;
@@ -154,6 +172,14 @@ class BinaryReader {
     }
     readU128() {
         const buf = this.readBuffer(16);
+        return new bn_js_1.default(buf, 'le');
+    }
+    readU256() {
+        const buf = this.readBuffer(32);
+        return new bn_js_1.default(buf, 'le');
+    }
+    readU512() {
+        const buf = this.readBuffer(64);
         return new bn_js_1.default(buf, 'le');
     }
     readBuffer(len) {
@@ -192,6 +218,9 @@ __decorate([
 ], BinaryReader.prototype, "readU8", null);
 __decorate([
     handlingRangeError
+], BinaryReader.prototype, "readU16", null);
+__decorate([
+    handlingRangeError
 ], BinaryReader.prototype, "readU32", null);
 __decorate([
     handlingRangeError
@@ -199,6 +228,12 @@ __decorate([
 __decorate([
     handlingRangeError
 ], BinaryReader.prototype, "readU128", null);
+__decorate([
+    handlingRangeError
+], BinaryReader.prototype, "readU256", null);
+__decorate([
+    handlingRangeError
+], BinaryReader.prototype, "readU512", null);
 __decorate([
     handlingRangeError
 ], BinaryReader.prototype, "readString", null);


### PR DESCRIPTION
This expands the different possibilities for large unsigned numbers, including `u256` and `u512`.  Also, the implementation for `u16` was missing, so add that in as well!

The `u256` and `u512` are particularly useful for public keys represented as a `BN` in front-end code. 