### PR TITLE
Add deserialize function which omits length check

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -329,3 +329,9 @@ export function deserialize(schema: Schema, classType: any, buffer: Buffer): any
     }
     return result;
 }
+
+/// Deserializes object from bytes using schema, without checking the length read
+export function deserializeUnchecked(schema: Schema, classType: any, buffer: Buffer): any {
+    const reader = new BinaryReader(buffer);
+    return deserializeStruct(schema, classType, reader);
+}


### PR DESCRIPTION
If we want to read a buffer that contains some padding at the end, Borsh
throws an error.  This is a valid usecase though, so expose an additional
function to do that.

Alternatively, we can expose `deserializeStruct` and let people
implement their own version.  Otherwise, people (me) have had to
copy code straight from this repo.  See
https://github.com/identity-com/solid-did/blob/main/client/src/lib/solana/solana-borsh.ts#L38
for my bad example.

I went with the `deserializeUnchecked` for the function name, but other possible names
for the function: `deserializeIncomplete`, `deserializeWithPadding`.

Let me know if you have any questions!