### PR TITLE
Correct `writeU64` and `writeU128` type signatures

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -65,12 +65,12 @@ export class BinaryWriter {
         this.length += 4;
     }
 
-    public writeU64(value: BN) {
+    public writeU64(value: number | BN) {
         this.maybeResize();
         this.writeBuffer(Buffer.from(new BN(value).toArray('le', 8)));
     }
 
-    public writeU128(value: BN) {
+    public writeU128(value: number | BN) {
         this.maybeResize();
         this.writeBuffer(Buffer.from(new BN(value).toArray('le', 16)));
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -16,8 +16,8 @@ export declare class BinaryWriter {
     maybeResize(): void;
     writeU8(value: number): void;
     writeU32(value: number): void;
-    writeU64(value: BN): void;
-    writeU128(value: BN): void;
+    writeU64(value: number | BN): void;
+    writeU128(value: number | BN): void;
     private writeBuffer;
     writeString(str: string): void;
     writeFixedArray(array: Uint8Array): void;


### PR DESCRIPTION
This is a trivial PR to correct the type signatures of `BinaryWriter#writeU64` and `BinaryWriter#writeU128`.

These two methods in fact accept both fixnums and BNs, given that the argument is passed to `new BN(value)`. That's a nice convenience for the user, and worth documenting in the type signature.