### PR TITLE
Add option support to deserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Install dependencies:
 yarn install
 ```
 
-Continuesly build with:
+Continuously build with:
 ```bash
 yarn dev
 ```

--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -252,7 +252,7 @@ function serializeField(schema: Schema, fieldName: string, value: any, fieldType
         } else if (fieldType.kind !== undefined) {
             switch (fieldType.kind) {
             case 'option': {
-                if (value === null) {
+                if (value === null || value === undefined) {
                     writer.writeU8(0);
                 } else {
                     writer.writeU8(1);
@@ -317,6 +317,20 @@ function deserializeField(schema: Schema, fieldName: string, fieldType: any, rea
             }
 
             return reader.readArray(() => deserializeField(schema, fieldName, fieldType[0], reader));
+        }
+
+        if (fieldType.kind === 'option') {
+            const option = reader.readU8();
+            if (option) {
+                return deserializeField(
+                    schema,
+                    fieldName,
+                    fieldType.type,
+                    reader
+                );
+            }
+      
+            return undefined;
         }
 
         return deserializeStruct(schema, fieldType, reader);

--- a/borsh-ts/test/serialize.test.js
+++ b/borsh-ts/test/serialize.test.js
@@ -22,6 +22,18 @@ test('serialize object', async () => {
     expect(newValue.q).toEqual(new Uint8Array([1, 2, 3]));
 });
 
+test('serialize optional field', async () => {
+    const schema = new Map([[Test, { kind: 'struct', fields: [['x', { kind: 'option', type: 'string' }]]}]]);
+
+    let buf = borsh.serialize(schema, new Test({ x: '123', }));
+    let newValue = borsh.deserialize(schema, Test, buf);
+    expect(newValue.x).toEqual('123');
+
+    buf = borsh.serialize(schema, new Test({ }));
+    newValue = borsh.deserialize(schema, Test, buf);
+    expect(newValue.x).toEqual(undefined);
+});
+
 test('serialize max uint', async () => {
     const u64MaxHex = 'ffffffffffffffff';
     const value = new Test({

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,8 +19,8 @@ export declare class BinaryWriter {
     writeU32(value: number): void;
     writeU64(value: number | BN): void;
     writeU128(value: number | BN): void;
-    writeU256(value: BN): void;
-    writeU512(value: BN): void;
+    writeU256(value: number | BN): void;
+    writeU512(value: number | BN): void;
     private writeBuffer;
     writeString(str: string): void;
     writeFixedArray(array: Uint8Array): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,8 +19,8 @@ export declare class BinaryWriter {
     writeU32(value: number): void;
     writeU64(value: number | BN): void;
     writeU128(value: number | BN): void;
-    writeU256(value: number | BN): void;
-    writeU512(value: number | BN): void;
+    writeU256(value: BN): void;
+    writeU512(value: BN): void;
     private writeBuffer;
     writeString(str: string): void;
     writeFixedArray(array: Uint8Array): void;
@@ -45,3 +45,4 @@ export declare class BinaryReader {
 }
 export declare function serialize(schema: Schema, obj: any): Uint8Array;
 export declare function deserialize(schema: Schema, classType: any, buffer: Buffer): any;
+export declare function deserializeUnchecked(schema: Schema, classType: any, buffer: Buffer): any;

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.deserialize = exports.serialize = exports.BinaryReader = exports.BinaryWriter = exports.BorshError = exports.baseDecode = exports.baseEncode = void 0;
+exports.deserializeUnchecked = exports.deserialize = exports.serialize = exports.BinaryReader = exports.BinaryWriter = exports.BorshError = exports.baseDecode = exports.baseEncode = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
 const bs58_1 = __importDefault(require("bs58"));
 // TODO: Make sure this polyfill not included when not required
@@ -267,7 +267,7 @@ function serializeField(schema, fieldName, value, fieldType, writer) {
         else if (fieldType.kind !== undefined) {
             switch (fieldType.kind) {
                 case 'option': {
-                    if (value === null) {
+                    if (value === null || value === undefined) {
                         writer.writeU8(0);
                     }
                     else {
@@ -334,6 +334,13 @@ function deserializeField(schema, fieldName, fieldType, reader) {
             }
             return reader.readArray(() => deserializeField(schema, fieldName, fieldType[0], reader));
         }
+        if (fieldType.kind === 'option') {
+            const option = reader.readU8();
+            if (option) {
+                return deserializeField(schema, fieldName, fieldType.type, reader);
+            }
+            return undefined;
+        }
         return deserializeStruct(schema, fieldType, reader);
     }
     catch (error) {
@@ -376,3 +383,9 @@ function deserialize(schema, classType, buffer) {
     return result;
 }
 exports.deserialize = deserialize;
+/// Deserializes object from bytes using schema, without checking the length read
+function deserializeUnchecked(schema, classType, buffer) {
+    const reader = new BinaryReader(buffer);
+    return deserializeStruct(schema, classType, reader);
+}
+exports.deserializeUnchecked = deserializeUnchecked;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "borsh",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "Binary Object Representation Serializer for Hashing",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "borsh",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Binary Object Representation Serializer for Hashing",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,7 +23,7 @@
     "serializer",
     "deserializer",
     "consistency",
-    "determenistic"
+    "deterministic"
   ],
   "author": "Near Inc",
   "license": "Apache-2.0",


### PR DESCRIPTION
Right now optional fiels are only supported during serialization, this PR is adding support for kind=option for deserialization as well.