### PR TITLE
deserialize returns instance of `classType`

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -346,7 +346,7 @@ function deserializeField(schema: Schema, fieldName: string, fieldType: any, rea
                     reader
                 );
             }
-      
+
             return undefined;
         }
 
@@ -391,7 +391,7 @@ function deserializeStruct(schema: Schema, classType: any, reader: BinaryReader)
 }
 
 /// Deserializes object from bytes using schema.
-export function deserialize(schema: Schema, classType: any, buffer: Buffer): any {
+export function deserialize<T>( schema: Schema, classType: { new (args: any): T }, buffer: Buffer): T {
     const reader = new BinaryReader(buffer);
     const result = deserializeStruct(schema, classType, reader);
     if (reader.offset < buffer.length) {
@@ -401,7 +401,7 @@ export function deserialize(schema: Schema, classType: any, buffer: Buffer): any
 }
 
 /// Deserializes object from bytes using schema, without checking the length read
-export function deserializeUnchecked(schema: Schema, classType: any, buffer: Buffer): any {
+export function deserializeUnchecked<T>(schema: Schema, classType: {new (args: any): T}, buffer: Buffer): T {
     const reader = new BinaryReader(buffer);
     return deserializeStruct(schema, classType, reader);
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -44,5 +44,9 @@ export declare class BinaryReader {
     readArray(fn: any): any[];
 }
 export declare function serialize(schema: Schema, obj: any): Uint8Array;
-export declare function deserialize(schema: Schema, classType: any, buffer: Buffer): any;
-export declare function deserializeUnchecked(schema: Schema, classType: any, buffer: Buffer): any;
+export declare function deserialize<T>(schema: Schema, classType: {
+    new (args: any): T;
+}, buffer: Buffer): T;
+export declare function deserializeUnchecked<T>(schema: Schema, classType: {
+    new (args: any): T;
+}, buffer: Buffer): T;


### PR DESCRIPTION
this PR allow to skip type assertion on `deserialize` function
```ts
let instance: MyClass;

// before: deserialize returns type `any`
instance = deserialize(schema, MyClass, buffer) as MyClass;

// after: deserialize returns type `MyClass`
instance = deserialize(schema, MyClass, buffer);
```