### PR TITLE
use custom Writer/Reader

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -310,8 +310,8 @@ function serializeStruct(schema: Schema, obj: any, writer: BinaryWriter) {
 
 /// Serialize given object using schema of the form:
 /// { class_name -> [ [field_name, field_type], .. ], .. }
-export function serialize(schema: Schema, obj: any): Uint8Array {
-    const writer = new BinaryWriter();
+export function serialize(schema: Schema, obj: any, Writer = BinaryWriter): Uint8Array {
+    const writer = new Writer();
     serializeStruct(schema, obj, writer);
     return writer.toArray();
 }
@@ -391,8 +391,8 @@ function deserializeStruct(schema: Schema, classType: any, reader: BinaryReader)
 }
 
 /// Deserializes object from bytes using schema.
-export function deserialize<T>( schema: Schema, classType: { new (args: any): T }, buffer: Buffer): T {
-    const reader = new BinaryReader(buffer);
+export function deserialize<T>( schema: Schema, classType: { new (args: any): T }, buffer: Buffer, Reader = BinaryReader): T {
+    const reader = new Reader(buffer);
     const result = deserializeStruct(schema, classType, reader);
     if (reader.offset < buffer.length) {
         throw new BorshError(`Unexpected ${buffer.length - reader.offset} bytes after deserialized data`);
@@ -401,7 +401,7 @@ export function deserialize<T>( schema: Schema, classType: { new (args: any): T 
 }
 
 /// Deserializes object from bytes using schema, without checking the length read
-export function deserializeUnchecked<T>(schema: Schema, classType: {new (args: any): T}, buffer: Buffer): T {
-    const reader = new BinaryReader(buffer);
+export function deserializeUnchecked<T>(schema: Schema, classType: {new (args: any): T}, buffer: Buffer, Reader = BinaryReader): T {
+    const reader = new Reader(buffer);
     return deserializeStruct(schema, classType, reader);
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -43,10 +43,10 @@ export declare class BinaryReader {
     readFixedArray(len: number): Uint8Array;
     readArray(fn: any): any[];
 }
-export declare function serialize(schema: Schema, obj: any): Uint8Array;
+export declare function serialize(schema: Schema, obj: any, Writer?: typeof BinaryWriter): Uint8Array;
 export declare function deserialize<T>(schema: Schema, classType: {
     new (args: any): T;
-}, buffer: Buffer): T;
+}, buffer: Buffer, Reader?: typeof BinaryReader): T;
 export declare function deserializeUnchecked<T>(schema: Schema, classType: {
     new (args: any): T;
-}, buffer: Buffer): T;
+}, buffer: Buffer, Reader?: typeof BinaryReader): T;

--- a/lib/index.js
+++ b/lib/index.js
@@ -329,8 +329,8 @@ function serializeStruct(schema, obj, writer) {
 }
 /// Serialize given object using schema of the form:
 /// { class_name -> [ [field_name, field_type], .. ], .. }
-function serialize(schema, obj) {
-    const writer = new BinaryWriter();
+function serialize(schema, obj, Writer = BinaryWriter) {
+    const writer = new Writer();
     serializeStruct(schema, obj, writer);
     return writer.toArray();
 }
@@ -398,8 +398,8 @@ function deserializeStruct(schema, classType, reader) {
     throw new BorshError(`Unexpected schema kind: ${structSchema.kind} for ${classType.constructor.name}`);
 }
 /// Deserializes object from bytes using schema.
-function deserialize(schema, classType, buffer) {
-    const reader = new BinaryReader(buffer);
+function deserialize(schema, classType, buffer, Reader = BinaryReader) {
+    const reader = new Reader(buffer);
     const result = deserializeStruct(schema, classType, reader);
     if (reader.offset < buffer.length) {
         throw new BorshError(`Unexpected ${buffer.length - reader.offset} bytes after deserialized data`);
@@ -408,8 +408,8 @@ function deserialize(schema, classType, buffer) {
 }
 exports.deserialize = deserialize;
 /// Deserializes object from bytes using schema, without checking the length read
-function deserializeUnchecked(schema, classType, buffer) {
-    const reader = new BinaryReader(buffer);
+function deserializeUnchecked(schema, classType, buffer, Reader = BinaryReader) {
+    const reader = new Reader(buffer);
     return deserializeStruct(schema, classType, reader);
 }
 exports.deserializeUnchecked = deserializeUnchecked;


### PR DESCRIPTION
Allow specify custom Writer/Reader, like this:

```js
class ExtendedWriter extends borsh.BinaryWriter {
    writeDate(value) {
        this.writeU64(value.getTime());
    }
}
class ExtendedReader extends borsh.BinaryReader {
    readDate() {
        const value = this.readU64();
        return new Date(value.toNumber());
    }
}

const value = new Test({ x: new Date('Aug 12, 2021 12:00:00 UTC+00:00') });
const schema = new Map([[Test, {kind: 'struct', fields: [['x', 'date']]}]]);

const buf = borsh.serialize(schema, value, ExtendedWriter);
const newValue = borsh.deserialize(schema, Test, buf, ExtendedReader);
newValue instanceof Date // true
```