### PR TITLE
Add basic types

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -19,17 +19,17 @@ export function baseDecode(value: string): Buffer {
 
 const INITIAL_LENGTH = 1024;
 
-type FieldType = 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'u256' | 'u512' | 'f32' | 'f64' | [number] | [FieldType, number] | {kind: 'option'; type: FieldType};
+export type FieldType = 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'u256' | 'u512' | 'f32' | 'f64' | [number] | [FieldType, number] | {kind: 'option'; type: FieldType};
 
-type StructTypeInstance = {
+export type StructTypeInstance = {
     kind: 'struct';
     fields: Field[];
 }
 
-type EnumTypeInstance = {kind: 'enum'; field: string; values: Array<[string, FieldType]>}
+export type EnumTypeInstance = {kind: 'enum'; field: string; values: Array<[string, FieldType]>}
 
-type Field = [string, FieldType];
-type TypeInstance = StructTypeInstance | EnumTypeInstance;
+export type Field = [string, FieldType];
+export type TypeInstance = StructTypeInstance | EnumTypeInstance;
 
 export type Schema = Map<Function, TypeInstance>
 


### PR DESCRIPTION
As a first time consumer of this library, I had trouble figuring out what I could / couldn't do. Adding these types should help people understand the library a little bit better.

I'm not an expert on this library yet, so I'm hoping one of the maintainers can check these types and confirm they make sense based on the implementation. 

My next steps in an upcoming PR is to remove more instances of `any` to get some extra type safety internally. But for now this should help out consumers of the lib.