### PR TITLE
Change TextDecoder resolution to not rely on `global`

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -3,11 +3,11 @@ import bs58 from "bs58";
 
 // TODO: Make sure this polyfill not included when not required
 import * as encoding from "text-encoding-utf-8";
-const TextDecoder =
-  typeof (global as any).TextDecoder !== "function"
+const ResolvedTextDecoder =
+  typeof TextDecoder !== "function"
     ? encoding.TextDecoder
-    : (global as any).TextDecoder;
-const textDecoder = new TextDecoder("utf-8", { fatal: true });
+    : TextDecoder;
+const textDecoder = new ResolvedTextDecoder("utf-8", { fatal: true });
 
 export function baseEncode(value: Uint8Array | string): string {
   if (typeof value === "string") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,10 +33,10 @@ const bn_js_1 = __importDefault(require("bn.js"));
 const bs58_1 = __importDefault(require("bs58"));
 // TODO: Make sure this polyfill not included when not required
 const encoding = __importStar(require("text-encoding-utf-8"));
-const TextDecoder = typeof global.TextDecoder !== "function"
+const ResolvedTextDecoder = typeof TextDecoder !== "function"
     ? encoding.TextDecoder
-    : global.TextDecoder;
-const textDecoder = new TextDecoder("utf-8", { fatal: true });
+    : TextDecoder;
+const textDecoder = new ResolvedTextDecoder("utf-8", { fatal: true });
 function baseEncode(value) {
     if (typeof value === "string") {
         value = Buffer.from(value, "utf8");


### PR DESCRIPTION
`global` does not exist in the browser without Node polyfills, and we shouldn't assume their presence.

Fixes #38 