### PR TITLE
Serialize and deserialize support for `Map` type.

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -291,6 +291,14 @@ function serializeField(
           }
           break;
         }
+        case "map": {
+          writer.writeU32(value.size);
+          value.forEach((val, key) => {
+            serializeField(schema, fieldName, key, fieldType.key, writer);
+            serializeField(schema, fieldName, val, fieldType.value, writer);
+          });
+          break;
+        }
         default:
           throw new BorshError(`FieldType ${fieldType} unrecognized`);
       }
@@ -383,6 +391,16 @@ function deserializeField(
       }
 
       return undefined;
+    }
+    if (fieldType.kind === "map") {
+      let map = new Map();
+      const length = reader.readU32();
+      for (let i = 0; i < length; i++) {
+        const key = deserializeField(schema, fieldName, fieldType.key, reader);
+        const val = deserializeField(schema, fieldName, fieldType.value, reader);
+        map.set(key, val);
+      }
+      return map
     }
 
     return deserializeStruct(schema, fieldType, reader);

--- a/borsh-ts/test/serialize.test.js
+++ b/borsh-ts/test/serialize.test.js
@@ -181,3 +181,24 @@ test('serialize with custom writer/reader', async () => {
     const newValue = borsh.deserialize(schema, Test, buf, ExtendedReader);
     expect(newValue.x).toEqual(new Date(time));
 });
+
+test('serialize map', async () => {
+    let map = new Map();
+    for (let i = 0; i < 10; i++) {
+        map.set(new BN(i * 10), "some string " + i.toString());
+    }
+    const value = new Test({ x: map });
+    const schema = new Map([[ Test, {
+        kind: 'struct',
+        fields: [
+            ['x', { kind: 'map', key: 'u64', value: 'string' }],
+        ],
+    }]]);
+
+    const buf = borsh.serialize(schema, value);
+    const deserialized = borsh.deserialize(schema, Test, buf);
+    expect(deserialized.x.size).toEqual(10);
+    deserialized.x.forEach((value, key) => {
+        expect(value).toEqual("some string " + (key.toNumber() / 10).toString());
+    });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -292,6 +292,14 @@ function serializeField(schema, fieldName, value, fieldType, writer) {
                     }
                     break;
                 }
+                case "map": {
+                    writer.writeU32(value.size);
+                    value.forEach((val, key) => {
+                        serializeField(schema, fieldName, key, fieldType.key, writer);
+                        serializeField(schema, fieldName, val, fieldType.value, writer);
+                    });
+                    break;
+                }
                 default:
                     throw new BorshError(`FieldType ${fieldType} unrecognized`);
             }
@@ -370,6 +378,16 @@ function deserializeField(schema, fieldName, fieldType, reader) {
                 return deserializeField(schema, fieldName, fieldType.type, reader);
             }
             return undefined;
+        }
+        if (fieldType.kind === "map") {
+            let map = new Map();
+            const length = reader.readU32();
+            for (let i = 0; i < length; i++) {
+                const key = deserializeField(schema, fieldName, fieldType.key, reader);
+                const val = deserializeField(schema, fieldName, fieldType.value, reader);
+                map.set(key, val);
+            }
+            return map;
         }
         return deserializeStruct(schema, fieldType, reader);
     }


### PR DESCRIPTION
It would be nice if Borsh-js would support `Map` types out of the box.

For example, I would like to use a rust `BTreeMap` type on the contract side that can be serialized/deserialized on the client side in a `Map` type. As far as I know, `BTreeMap`s are serialized similarly to a `Vec`, namely there is 4 bytes reserved at the front to encode the length (size) in LE representation, then the keys and values are serialized in a sorted sequence, so, contrary to a `HashMap` type, there's no danger of iterating over the key-value pairs randomly.

What do you guys think?