### PR TITLE
Change TextDecoder from global to globalThis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ const bn_js_1 = __importDefault(require("bn.js"));
 const bs58_1 = __importDefault(require("bs58"));
 // TODO: Make sure this polyfill not included when not required
 const encoding = __importStar(require("text-encoding-utf-8"));
-const TextDecoder = typeof global.TextDecoder !== "function"
+const TextDecoder = typeof globalThis.TextDecoder !== "function"
     ? encoding.TextDecoder
     : global.TextDecoder;
 const textDecoder = new TextDecoder("utf-8", { fatal: true });


### PR DESCRIPTION
Change from `global.TextDecoder` to `globalThis.TextDecoder` cause the global keyword cannot be recognized in the browser and not all libraries that rely on this are run on a Node.js library. 

Also fixes #38 