### PR TITLE
fix: add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "bn.js": "^5.2.0",
     "bs58": "^4.0.0",
+    "buffer": "^6.0.3",
     "text-encoding-utf-8": "^1.0.2"
   }
 }


### PR DESCRIPTION
Newest near-api-js breaks unless I also `yarn install buffer`. Seems to be related to the `borsh` dependency, which does not currently include `borsh` in its deps.