### PR TITLE
The writer now accepts `bigint` and the reader now always returns `bigint` for numbers 64 bits and larger

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ const newValue = borsh.deserialize(schema, Test, buffer);
 | `u8` integer          | `number`       |
 | `u16` integer         | `number`       |
 | `u32` integer         | `number`       |
-| `u64` integer         | `BN`           |
-| `u128` integer        | `BN`           |
-| `u256` integer        | `BN`           |
-| `u512` integer        | `BN`           |
+| `u64` integer         | `bigint`       |
+| `u128` integer        | `bigint`       |
+| `u256` integer        | `bigint`       |
+| `u512` integer        | `bigint`       |
 | `f32` float           | N/A            |
 | `f64` float           | N/A            |
 | fixed-size byte array | `Uint8Array`   |

--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -1,4 +1,4 @@
-import {toBufferLE} from 'bigint-buffer';
+import {toBigIntLE, toBufferLE} from 'bigint-buffer';
 import type BN from 'bn.js';
 import bs58 from 'bs58';
 
@@ -194,12 +194,7 @@ export class BinaryReader {
 
     private readBigInteger(bytes: 8 | 16 | 32 | 64): bigint {
         const buf = this.readBuffer(bytes);
-        let ret = 0n;
-        for (let ii = 1; ii <= bytes; ii++) {
-            const byte = buf[bytes - ii];
-            ret = (ret << 8n) + BigInt(byte);
-        }
-        return ret;
+        return toBigIntLE(buf);
     }
 
     @handlingRangeError

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import BN from 'bn.js';
+import type BN from 'bn.js';
 export declare function baseEncode(value: Uint8Array | string): string;
 export declare function baseDecode(value: string): Buffer;
 export declare type Schema = Map<Function, any>;
@@ -17,10 +17,11 @@ export declare class BinaryWriter {
     writeU8(value: number): void;
     writeU16(value: number): void;
     writeU32(value: number): void;
-    writeU64(value: number | BN): void;
-    writeU128(value: number | BN): void;
-    writeU256(value: number | BN): void;
-    writeU512(value: number | BN): void;
+    private writeBigInteger;
+    writeU64(value: number | bigint | BN): void;
+    writeU128(value: number | bigint | BN): void;
+    writeU256(value: number | bigint | BN): void;
+    writeU512(value: number | bigint | BN): void;
     private writeBuffer;
     writeString(str: string): void;
     writeFixedArray(array: Uint8Array): void;
@@ -34,10 +35,11 @@ export declare class BinaryReader {
     readU8(): number;
     readU16(): number;
     readU32(): number;
-    readU64(): BN;
-    readU128(): BN;
-    readU256(): BN;
-    readU512(): BN;
+    private readBigInteger;
+    readU64(): bigint;
+    readU128(): bigint;
+    readU256(): bigint;
+    readU512(): bigint;
     private readBuffer;
     readString(): string;
     readFixedArray(len: number): Uint8Array;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.deserializeUnchecked = exports.deserialize = exports.serialize = exports.BinaryReader = exports.BinaryWriter = exports.BorshError = exports.baseDecode = exports.baseEncode = void 0;
+const bigint_buffer_1 = require("bigint-buffer");
 const bs58_1 = __importDefault(require("bs58"));
 // TODO: Make sure this polyfill not included when not required
 const encoding = __importStar(require("text-encoding-utf-8"));
@@ -49,18 +50,6 @@ function baseDecode(value) {
     return Buffer.from(bs58_1.default.decode(value));
 }
 exports.baseDecode = baseDecode;
-function getLEByteBufferFromNumber(n, byteLength) {
-    let hex = n.toString(16);
-    if (hex.length % 2) {
-        hex = '0' + hex;
-    }
-    const bytes = new Uint8Array(byteLength);
-    hex
-        .match(/../g)
-        .reverse()
-        .forEach((s, i) => { bytes[i] = parseInt(s, 16); });
-    return Buffer.from(bytes);
-}
 const INITIAL_LENGTH = 1024;
 class BorshError extends Error {
     originalMessage;
@@ -106,9 +95,18 @@ class BinaryWriter {
     }
     writeBigInteger(value, bytes) {
         this.maybeResize();
-        this.writeBuffer(typeof value === 'object'
-            ? value.toBuffer('le', bytes)
-            : getLEByteBufferFromNumber(value, bytes));
+        let buffer;
+        if (typeof value === 'object') {
+            // By process of elimination, `value` is an instance of `BN`.
+            buffer = value.toBuffer('le', bytes);
+        }
+        else {
+            if (typeof value === 'number') {
+                value = BigInt(value);
+            }
+            buffer = (0, bigint_buffer_1.toBufferLE)(value, bytes);
+        }
+        this.writeBuffer(buffer);
     }
     writeU64(value) {
         this.writeBigInteger(value, 8);

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.deserializeUnchecked = exports.deserialize = exports.serialize = exports.BinaryReader = exports.BinaryWriter = exports.BorshError = exports.baseDecode = exports.baseEncode = void 0;
-const bn_js_1 = __importDefault(require("bn.js"));
 const bs58_1 = __importDefault(require("bs58"));
 // TODO: Make sure this polyfill not included when not required
 const encoding = __importStar(require("text-encoding-utf-8"));
@@ -50,6 +49,18 @@ function baseDecode(value) {
     return Buffer.from(bs58_1.default.decode(value));
 }
 exports.baseDecode = baseDecode;
+function getLEByteBufferFromNumber(n, byteLength) {
+    let hex = n.toString(16);
+    if (hex.length % 2) {
+        hex = '0' + hex;
+    }
+    const bytes = new Uint8Array(byteLength);
+    hex
+        .match(/../g)
+        .reverse()
+        .forEach((s, i) => { bytes[i] = parseInt(s, 16); });
+    return Buffer.from(bytes);
+}
 const INITIAL_LENGTH = 1024;
 class BorshError extends Error {
     originalMessage;
@@ -93,21 +104,23 @@ class BinaryWriter {
         this.buf.writeUInt32LE(value, this.length);
         this.length += 4;
     }
-    writeU64(value) {
+    writeBigInteger(value, bytes) {
         this.maybeResize();
-        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 8)));
+        this.writeBuffer(typeof value === 'object'
+            ? value.toBuffer('le', bytes)
+            : getLEByteBufferFromNumber(value, bytes));
+    }
+    writeU64(value) {
+        this.writeBigInteger(value, 8);
     }
     writeU128(value) {
-        this.maybeResize();
-        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 16)));
+        this.writeBigInteger(value, 16);
     }
     writeU256(value) {
-        this.maybeResize();
-        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 32)));
+        this.writeBigInteger(value, 32);
     }
     writeU512(value) {
-        this.maybeResize();
-        this.writeBuffer(Buffer.from(new bn_js_1.default(value).toArray('le', 64)));
+        this.writeBigInteger(value, 64);
     }
     writeBuffer(buffer) {
         // Buffer.from is needed as this.buf.subarray can return plain Uint8Array in browser
@@ -179,21 +192,26 @@ class BinaryReader {
         this.offset += 4;
         return value;
     }
+    readBigInteger(bytes) {
+        const buf = this.readBuffer(bytes);
+        let ret = 0n;
+        for (let ii = 1; ii <= bytes; ii++) {
+            const byte = buf[bytes - ii];
+            ret = (ret << 8n) + BigInt(byte);
+        }
+        return ret;
+    }
     readU64() {
-        const buf = this.readBuffer(8);
-        return new bn_js_1.default(buf, 'le');
+        return this.readBigInteger(8);
     }
     readU128() {
-        const buf = this.readBuffer(16);
-        return new bn_js_1.default(buf, 'le');
+        return this.readBigInteger(16);
     }
     readU256() {
-        const buf = this.readBuffer(32);
-        return new bn_js_1.default(buf, 'le');
+        return this.readBigInteger(32);
     }
     readU512() {
-        const buf = this.readBuffer(64);
-        return new bn_js_1.default(buf, 'le');
+        return this.readBigInteger(64);
     }
     readBuffer(len) {
         if (this.offset + len > this.buf.length) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -192,12 +192,7 @@ class BinaryReader {
     }
     readBigInteger(bytes) {
         const buf = this.readBuffer(bytes);
-        let ret = 0n;
-        for (let ii = 1; ii <= bytes; ii++) {
-            const byte = buf[bytes - ii];
-            ret = (ret << 8n) + BigInt(byte);
-        }
-        return ret;
+        return (0, bigint_buffer_1.toBigIntLE)(buf);
     }
     readU64() {
         return this.readBigInteger(8);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node": "^12.7.3",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
+    "bn.js": "^5.2.0",
     "bs58": "^4.0.0",
     "eslint": "^8.17.0",
     "jest": "^26.0.1",
@@ -51,7 +52,6 @@
     "typescript": "^4"
   },
   "dependencies": {
-    "bn.js": "^5.2.0",
     "bs58": "^4.0.0",
     "buffer": "^6.0.3",
     "text-encoding-utf-8": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^4"
   },
   "dependencies": {
+    "bigint-buffer": "^1.1.5",
     "bs58": "^4.0.0",
     "buffer": "^6.0.3",
     "text-encoding-utf-8": "^1.0.2"


### PR DESCRIPTION
#### Problem statement

Certain applications target runtimes that support JavaScript's `BigInt`. If such an application takes a dependency on `borsh-js`, it's nevertheless forced to bundle the `bn.js` polyfill.

Consider a library like `@solana/web3.js`. `bn.js` makes up ~13% of its bundle size (a whopping 35K):

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/13243/187104946-db82b2a7-3517-4795-9deb-19a40a34bc4c.png">

If such a library could install a version of `borsh-js` that dealt in native `BigInt` values, then it could eliminate its dependency on `bn.js` and reduce its bundle size.

#### Summary of changes

* Augment the writers to understand `number`, `bigint`, and `BN` values.
* Modify the readers to always return `bigint` for numbers 64 bits and larger.
* Implement bigint-to-buffer conversion using `bigint-buffer`; an efficient browser implementation paired with a native C implementation when run in Node.js (thanks for the suggestion @marcus-pousette).

#### Test plan

```
yarn test
```

#### Notes

This represents a breaking change, since deserialized numbers 64 bits or larger will now be of type `bigint` when they were previously of type `BN`.

`BigInt` is supported by every major browser released since September 15 2020: https://caniuse.com/bigint