### PR TITLE
Search by class name instead of the class itself

### DIFF
--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -317,7 +317,14 @@ function serializeStruct(schema: Schema, obj: any, writer: BinaryWriter): void {
         return;
     }
 
-    const structSchema = schema.get(obj.constructor);
+    let structSchema = undefined;
+    for (const key of schema.keys()){
+        if (key.name == obj.constructor.name) {
+            structSchema = schema.get(key);
+            break;
+        }
+    }
+
     if (!structSchema) {
         throw new BorshError(`Class ${obj.constructor.name} is missing in schema`);
     }

--- a/borsh-ts/index.ts
+++ b/borsh-ts/index.ts
@@ -317,14 +317,7 @@ function serializeStruct(schema: Schema, obj: any, writer: BinaryWriter): void {
         return;
     }
 
-    let structSchema = undefined;
-    for (const key of schema.keys()){
-        if (key.name == obj.constructor.name) {
-            structSchema = schema.get(key);
-            break;
-        }
-    }
-
+const structSchema = schema.get(schema.keys().find((classConstructor) => (classConstructor.name === obj.constructor.name)));
     if (!structSchema) {
         throw new BorshError(`Class ${obj.constructor.name} is missing in schema`);
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,7 @@
 import BN from 'bn.js';
 export declare function baseEncode(value: Uint8Array | string): string;
 export declare function baseDecode(value: string): Buffer;
-export type Schema = Map<Function, any>;
+export declare type Schema = Map<Function, any>;
 export declare class BorshError extends Error {
     originalMessage: string;
     fieldPath: string[];

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,7 @@
 import BN from 'bn.js';
 export declare function baseEncode(value: Uint8Array | string): string;
 export declare function baseDecode(value: string): Buffer;
-export declare type Schema = Map<Function, any>;
+export type Schema = Map<Function, any>;
 export declare class BorshError extends Error {
     originalMessage: string;
     fieldPath: string[];

--- a/lib/index.js
+++ b/lib/index.js
@@ -327,7 +327,13 @@ function serializeStruct(schema, obj, writer) {
         obj.borshSerialize(writer);
         return;
     }
-    const structSchema = schema.get(obj.constructor);
+    let structSchema = undefined;
+    for (const key of schema.keys()) {
+        if (key.name == obj.constructor.name) {
+            structSchema = schema.get(key);
+            break;
+        }
+    }
     if (!structSchema) {
         throw new BorshError(`Class ${obj.constructor.name} is missing in schema`);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -327,13 +327,7 @@ function serializeStruct(schema, obj, writer) {
         obj.borshSerialize(writer);
         return;
     }
-    let structSchema = undefined;
-    for (const key of schema.keys()) {
-        if (key.name == obj.constructor.name) {
-            structSchema = schema.get(key);
-            break;
-        }
-    }
+const structSchema = schema.get(schema.keys().find((classConstructor) => (classConstructor.name === obj.constructor.name)));
     if (!structSchema) {
         throw new BorshError(`Class ${obj.constructor.name} is missing in schema`);
     }


### PR DESCRIPTION
Right now we are getting lots of errors when trying to deserialise the exact same class across different versions of `near-api-js`, `near-social-vm` and others, since the `SCHEMA` indexes by the `Class` itself. 

Therefore, I have changed the search inside the schema, so we look for the Class **name** instead of the Class. In this way, different versions of `Transaction` will point to the same schema.

This is a **non breaking change** that solves the problem without changing the Schemas, nor the expected behaviour of the serialised.