### PR TITLE
Homogenize example and remove reference to borsh-js

### DIFF
--- a/examples/cjs/index.js
+++ b/examples/cjs/index.js
@@ -1,4 +1,4 @@
-const borsh = require('borsh-js');
+const borsh = require('borsh');
 
 const encodedU16 = borsh.serialize('u16', 2);
 const decodedU16 = borsh.deserialize('u16', encodedU16);
@@ -7,3 +7,7 @@ console.log(decodedU16);
 const encodedStr = borsh.serialize('string', 'testing');
 const decodedStr = borsh.deserialize('string', encodedStr);
 console.log(decodedStr);
+
+const encodedU64 = borsh.serialize('u64', '100000000000000000');
+const decodedU64 = borsh.deserialize('u64', encodedU64);
+console.log(decodedU64);

--- a/examples/cjs/package.json
+++ b/examples/cjs/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0",
   "description": "",
   "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
   "dependencies": {
-    "borsh-js": "file:../../"
+    "borsh": "^2"
   }
 }

--- a/examples/esm/index.js
+++ b/examples/esm/index.js
@@ -1,9 +1,13 @@
-import * as borsh from 'borsh-js';
+import * as borsh from 'borsh';
 
 const encodedU16 = borsh.serialize('u16', 2);
 const decodedU16 = borsh.deserialize('u16', encodedU16);
 console.log(decodedU16);
 
-const encodedStr = borsh.serialize('u64', '100000000000000000');
-const decodedStr = borsh.deserialize('u64', encodedStr);
+const encodedStr = borsh.serialize('string', 'testing');
+const decodedStr = borsh.deserialize('string', encodedStr);
 console.log(decodedStr);
+
+const encodedU64 = borsh.serialize('u64', '100000000000000000');
+const decodedU64 = borsh.deserialize('u64', encodedU64);
+console.log(decodedU64);

--- a/examples/esm/package.json
+++ b/examples/esm/package.json
@@ -5,7 +5,10 @@
   "description": "",
   "type": "module",
   "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
   "dependencies": {
-    "borsh-js": "file:../../"
+    "borsh": "^2"
   }
 }


### PR DESCRIPTION
The current examples differ on what they encode / decode, but more importantly, they refer to a `borsh-js` package that does not exist

I have modified the dependencies to use the actual Borsh encoding, and homogenized the code so they execute exactly the same code